### PR TITLE
Use custom type for Input model

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,7 +1,8 @@
 module github.com/nDenerserve/SmartPi
 
-go 1.21.4
-toolchain go1.22.8
+go 1.22.6
+
+toolchain go1.23.1
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.5.0
@@ -10,7 +11,6 @@ require (
 	github.com/gorilla/context v1.1.2
 	github.com/gorilla/mux v1.8.1
 	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c
-	github.com/julien040/go-ternary v1.0.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/msteinert/pam v1.2.0
 	github.com/nDenerserve/RN2483 v0.0.0-20231123165121-2ab5d8f2030a

--- a/src/go.sum
+++ b/src/go.sum
@@ -48,8 +48,6 @@ github.com/jlaffaye/ftp v0.2.0/go.mod h1:is2Ds5qkhceAPy2xD6RLI6hmp/qysSoymZ+Z2uT
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
-github.com/julien040/go-ternary v1.0.0 h1:ZqoUWG9HZvcVu0426B7/jKS5eilgHeqp5X15+RvTP7g=
-github.com/julien040/go-ternary v1.0.0/go.mod h1:XXIcjDHL7vyuHA7V0UwaTKMscsqKzFkE9FTGbBeqJHM=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/src/models/inputtype.go
+++ b/src/models/inputtype.go
@@ -1,7 +1,25 @@
 package models
 
+type InputType int
+
 const (
 	NotUsed = iota
 	Voltage
 	Current
 )
+
+func (i InputType) String() string {
+	return [...]string{"NotUsed", "Voltage", "Current"}[i]
+}
+
+func (i InputType) UnitSymbol() string {
+	return [...]string{"N/A", "V", "A"}[i]
+}
+
+func InputTypesAsStrings(input []InputType) []string {
+	s := make([]string, len(input))
+	for i, v := range input {
+		s[i] = v.String()
+	}
+	return s
+}

--- a/src/smartpidc/files.go
+++ b/src/smartpidc/files.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/julien040/go-ternary"
 	"github.com/nDenerserve/SmartPi/models"
 	"github.com/nDenerserve/SmartPi/repository/config"
 	log "github.com/sirupsen/logrus"
@@ -27,7 +26,7 @@ type tMeasurement struct {
 	Values []tValue `json:"values" xml:"values"`
 }
 
-func WriteSharedFile(c *config.DCconfig, inputconfig []int, values []float64, power []float64, energyConsumed []float64, energyProduced []float64) {
+func WriteSharedFile(c *config.DCconfig, inputconfig []models.InputType, values []float64, power []float64, energyConsumed []float64, energyProduced []float64) {
 	var f *os.File
 	var err error
 	var measurement tMeasurement
@@ -41,9 +40,9 @@ func WriteSharedFile(c *config.DCconfig, inputconfig []int, values []float64, po
 	s = append(s, timeStamp)
 
 	for j := range values {
-		if inputconfig[j] != 0 {
+		if inputconfig[j] != models.NotUsed {
 			if !math.IsNaN(values[j]) {
-				measurement.Values = append(measurement.Values, tValue{Input: "input" + strconv.Itoa(j), Value: values[j], Unit: ternary.If(inputconfig[j] == models.Voltage, "V", "A")})
+				measurement.Values = append(measurement.Values, tValue{Input: "input" + strconv.Itoa(j), Value: values[j], Unit: inputconfig[j].UnitSymbol()})
 			}
 
 			s = append(s, fmt.Sprint(values[j]))

--- a/src/smartpidc/influxdatabase.go
+++ b/src/smartpidc/influxdatabase.go
@@ -15,13 +15,14 @@ import (
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	client "github.com/influxdata/influxdb1-client/v2"
+	"github.com/nDenerserve/SmartPi/models"
 	"github.com/nDenerserve/SmartPi/repository/config"
 	"github.com/nDenerserve/SmartPi/smartpi/network"
 
 	log "github.com/sirupsen/logrus"
 )
 
-func InsertInfluxData(c *config.DCconfig, inputconfig []int, values []float64, power []float64, energyConsumed []float64, energyProduced []float64) {
+func InsertInfluxData(c *config.DCconfig, inputconfig []models.InputType, values []float64, power []float64, energyConsumed []float64, energyProduced []float64) {
 
 	client := influxdb2.NewClient(c.Influxdatabase, c.InfluxAPIToken)
 	defer client.Close()

--- a/src/smartpidc/mqtt.go
+++ b/src/smartpidc/mqtt.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/nDenerserve/SmartPi/models"
 	"github.com/nDenerserve/SmartPi/repository/config"
 	log "github.com/sirupsen/logrus"
 )
@@ -47,7 +48,7 @@ func publishMQTT(m mqtt.Client, status *bool, t string, v float64) bool {
 	return false
 }
 
-func PublishMQTTReadouts(c *config.DCconfig, mqttclient mqtt.Client, inputconfig []int, values []float64, power []float64, energyConsumed []float64, energyProduced []float64) {
+func PublishMQTTReadouts(c *config.DCconfig, mqttclient mqtt.Client, inputconfig []models.InputType, values []float64, power []float64, energyConsumed []float64, energyProduced []float64) {
 	//[basetopic]/[node]/[keyname]
 	// Let's try to (re-)connect if MQTT connection was lost.
 	if !mqttclient.IsConnected() {


### PR DESCRIPTION
Use a Go style type alias for the input type enum. This allows an easy type safe string conversion from the iota to the desired string, avoiding package abstraction leakage.